### PR TITLE
[bison]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# bison
+
+A parser generator that converts an annotated context-free grammar into a parser
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.bison?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # bison
 
 A parser generator that converts an annotated context-free grammar into a parser

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_relative_path: '/bin/bison'

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,1 @@
-command_relative_path: '/bin/bison'
+command_relative_path: 'bin/bison'

--- a/controls/bison_exists.rb
+++ b/controls/bison_exists.rb
@@ -13,6 +13,7 @@ control 'core-plans-bison-exists' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
   end
 
   command_relative_path = input('command_relative_path', value: 'bin/bison')

--- a/controls/bison_exists.rb
+++ b/controls/bison_exists.rb
@@ -1,0 +1,22 @@
+title 'Tests to confirm bison exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'bison')
+ 
+control 'core-plans-bison-exists' do
+  impact 1.0
+  title 'Ensure bison exists'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  command_relative_path = input('command_relative_path', value: '/bin/bison')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  describe file(command_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/bison_exists.rb
+++ b/controls/bison_exists.rb
@@ -7,7 +7,8 @@ control 'core-plans-bison-exists' do
   impact 1.0
   title 'Ensure bison exists'
   desc '
-  '
+  Verify bison by ensuring /bin/bison exists'
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/controls/bison_exists.rb
+++ b/controls/bison_exists.rb
@@ -2,12 +2,12 @@ title 'Tests to confirm bison exists'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'bison')
- 
+
 control 'core-plans-bison-exists' do
   impact 1.0
   title 'Ensure bison exists'
   desc '
-  Verify bison by ensuring /bin/bison exists'
+  Verify bison by ensuring bin/bison exists'
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
@@ -15,8 +15,8 @@ control 'core-plans-bison-exists' do
     its('stdout') { should_not be_empty }
   end
 
-  command_relative_path = input('command_relative_path', value: '/bin/bison')
-  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  command_relative_path = input('command_relative_path', value: 'bin/bison')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
   describe file(command_full_path) do
     it { should exist }
   end

--- a/controls/bison_works.rb
+++ b/controls/bison_works.rb
@@ -7,7 +7,10 @@ control 'core-plans-bison-works' do
   impact 1.0
   title 'Ensure bison works as expected'
   desc '
+  Verify bison by ensuring (1) its installation directory exists and (2) that
+  it returns the expected version
   '
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/controls/bison_works.rb
+++ b/controls/bison_works.rb
@@ -16,6 +16,7 @@ control 'core-plans-bison-works' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
   end
   
   command_relative_path = input('command_relative_path', value: 'bin/bison')

--- a/controls/bison_works.rb
+++ b/controls/bison_works.rb
@@ -7,8 +7,9 @@ control 'core-plans-bison-works' do
   impact 1.0
   title 'Ensure bison works as expected'
   desc '
-  Verify bison by ensuring (1) its installation directory exists and (2) that
-  it returns the expected version
+  Verify bison by ensuring 
+  (1) its installation directory exists and 
+  (2) that it returns the expected version.
   '
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
@@ -17,9 +18,10 @@ control 'core-plans-bison-works' do
     its('stdout') { should_not be_empty }
   end
   
-  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
-  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} bison --version") do
+  command_relative_path = input('command_relative_path', value: 'bin/bison')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  describe command("#{command_full_path} --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /bison \(GNU Bison\) #{plan_pkg_version}/ }

--- a/controls/bison_works.rb
+++ b/controls/bison_works.rb
@@ -1,0 +1,25 @@
+title 'Tests to confirm bison works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'bison')
+
+control 'core-plans-bison-works' do
+  impact 1.0
+  title 'Ensure bison works as expected'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} bison --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /bison \(GNU Bison\) #{plan_pkg_version}/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: bison
+title: Habitat Core Plan bison
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan bison
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,42 @@
+pkg_name=bison
+pkg_origin=core
+pkg_version=3.4.1
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+Bison is a general-purpose parser generator that converts an annotated \
+context-free grammar into a deterministic LR or generalized LR (GLR) parser \
+employing LALR(1) parser tables.\
+"
+pkg_upstream_url="https://www.gnu.org/software/bison/"
+pkg_license=('GPL-3.0')
+pkg_source="http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.xz"
+pkg_shasum="27159ac5ebf736dffd5636fd2cd625767c9e437de65baa63cb0de83570bd820d"
+pkg_deps=(
+  core/glibc
+  core/m4
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+  core/perl
+)
+pkg_bin_dirs=(bin)
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/m4
+    core/coreutils
+  )
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,5 @@
+@test "bison --version output mentions expected version $expected_version" {
+  expected_version="$(echo $TEST_PKG_IDENT | cut -d/ -f3)"
+  actual_version=$(hab pkg exec $TEST_PKG_IDENT bison --version | head -n1 | cut -d' ' -f4)
+  [ "$actual_version" = "$expected_version" ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -euo pipefail
+
+TESTDIR="$(dirname "${0}")"
+
+if [ -z "${1:-}" ]; then
+  echo "Usage: $0 FULLY_QUALIFIED_PACKAGE_IDENT"
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "$TEST_PKG_IDENT"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
### Outstanding tasks:
- [x] remove DEBUG
- [x] use full path to binary instead of hab pkg exec
- [x] parsing the pkg_version from the installation path.

```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://01df5dba423e0396dfeec0957c09a5f5d54f8de557655d88821f06a6a3753f7c --input-file /src/attributes.yml

Profile: Habitat Core Plan bison (bison)
Version: 0.1.0
Target:  docker://01df5dba423e0396dfeec0957c09a5f5d54f8de557655d88821f06a6a3753f7c

  ✔  core-plans-bison-exists: Ensure bison exists
     ✔  File /hab/pkgs/core/bison/3.4.1/20200602213651/bin/bison is expected to exist
  ✔  core-plans-bison-works: Ensure bison works as expected
     ✔  Command: `hab pkg path core/bison` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/bison` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/bison/3.4.1/20200602213651 bison --version` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/bison/3.4.1/20200602213651 bison --version` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/bison/3.4.1/20200602213651 bison --version` stdout is expected to match /bison \(GNU Bison\) 3.4.1/
     ✔  Command: `DEBUG=true; hab pkg exec core/bison/3.4.1/20200602213651 bison --version` stderr is expected to be empty


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 7 successful, 0 failures, 0 skipped
```